### PR TITLE
Fixes issue #8: RunTimeWarning under Windows

### DIFF
--- a/daemoniker/_daemonize_windows.py
+++ b/daemoniker/_daemonize_windows.py
@@ -435,7 +435,7 @@ def _daemonize1(pid_file, *args, chdir=None, stdin_goto=None, stdout_goto=None,
                 # Figure out the path to the current file
                 # worker_target = os.path.abspath(__file__)
                 worker_cmd = ('"' + python_path + '" -m ' +
-                              'daemoniker._daemonize_windows ' +
+                              'daemoniker._daemonize_windows_main ' +
                               '"' + worker_argpath + '"')
                 
                 try:
@@ -567,8 +567,8 @@ def _get_clean_env():
             
     return env2
     
-    
-if __name__ == '__main__':
+
+def daemonize_main():
     ''' Do this so we can support process-based workers using Popen
     instead of multiprocessing, which would impose extra requirements
     on whatever code used Windows daemonization to avoid infinite

--- a/daemoniker/_daemonize_windows_main.py
+++ b/daemoniker/_daemonize_windows_main.py
@@ -1,0 +1,11 @@
+""" 
+
+This file is separate from _daemonize_windows to avoid a RuntimeWarning caused by 
+_daemonize_windows being both runned by python and imported by __init__
+
+"""
+
+from ._daemonize_windows import daemonize_main
+
+if __name__ == '__main__':
+    daemonize_main()

--- a/daemoniker/_signals_windows.py
+++ b/daemoniker/_signals_windows.py
@@ -216,7 +216,7 @@ class SignalHandler1(_SighandlerCore):
         python_path = sys.executable
         python_path = os.path.abspath(python_path)
         worker_cmd = ('"' + python_path + '" -m ' +
-                      'daemoniker._signals_windows')
+                      'daemoniker._signals_windows_main')
         worker_env = {'__CREATE_SIGHANDLER__': 'True'}
         worker_env.update(_get_clean_env())
         
@@ -315,7 +315,7 @@ class SignalHandler1(_SighandlerCore):
         _sketch_raise_in_main(exc)
     
     
-if __name__ == '__main__':
+def signals_main():
     ''' Do this so we can support process-based workers using Popen
     instead of multiprocessing, which would impose extra requirements
     on whatever code used Windows daemonization to avoid infinite

--- a/daemoniker/_signals_windows_main.py
+++ b/daemoniker/_signals_windows_main.py
@@ -1,0 +1,10 @@
+""" 
+
+This file is separate from _signals_windows to avoid a RuntimeWarning caused by 
+_signals_windows being both runned by python and imported by __init__
+
+"""
+from ._signals_windows import signals_main
+
+if __name__ == '__main__':
+    signals_main()


### PR DESCRIPTION
Separate windows daemonize and signals module from the __main__ script used by workers, thus avoiding the RuntimeWarning.

Tests ran on Windows 10, python 3.6 only.