### PR TITLE
Fixes Issue #9. Tests fail on windows due to unix style paths

### DIFF
--- a/tests/autotest/test_daemonize_windows.py
+++ b/tests/autotest/test_daemonize_windows.py
@@ -279,9 +279,9 @@ class Deamonizing_test(unittest.TestCase):
         '''
         with tempfile.TemporaryDirectory() as dirname:
             
-            pid_file = dirname + '/testpid.pid'
+            pid_file = os.path.join(dirname, 'testpid.pid')
             token = 2718282
-            res_path = dirname + '/response.txt'
+            res_path = os.path.join(dirname, 'response.txt')
             
             worker_env = {
                 '__TESTWORKER__': 'True',


### PR DESCRIPTION
# Issue
It seems after tests that the issue only occured on the first run of the tests. Files were created as a complete filename instead of a file in a sub folder.

Nonetheless, this fixes the issue.

# Fixes
Replace unix style string append with os.path.join.